### PR TITLE
Change composer.json "type" back to "wordpress-plugin" (#240)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "classicpress-research/classic-commerce",
   "description": "A simple, powerful and independent e-commerce platform. Sell anything with ease.",
   "homepage": "https://github.com/ClassicPress-research/classic-commerce",
-  "type": "classicpress-plugin",
+  "type": "wordpress-plugin",
   "license": "GPL-3.0-or-later",
   "prefer-stable": true,
   "minimum-stability": "dev",


### PR DESCRIPTION
This is for compatibility, since "wordpress-plugin" is a type recognized
by "composer/installers" but "classicpress-plugin" is not:

https://getcomposer.org/doc/faqs/how-do-i-install-a-package-to-a-custom-path-for-my-framework.md

> Note: You cannot use this to change the path of any package. This is
> only applicable to packages that require composer/installers and use a
> custom type that it handles.